### PR TITLE
add C++ to other languages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ let chunksOf4 = Array.from(digits.windows(4, 4));
 
 | language | library | chunks | windows | chunks of 0? | truncates windows? |
 |----------|---------|--------|---------|--------------|--------------------|
+| C++ | std::ranges::views | `chunk` | `slide` | undefined behavior | no |
 | Clojure | core | `partition` | `partition` | infinite empty lists | when insufficient padding;<br/>terminates after 1 |
 | Elm | List.Extra | `groupsOf` | `groupsOfWithStep` | empty list | no |
 | Haskell | split | `chunksOf` | `divvy` | infinite empty lists | yes |


### PR DESCRIPTION
TIL: [`std::ranges::views::chunk`](https://en.cppreference.com/w/cpp/ranges/chunk_view) and [`std::ranges::views::slide`](https://en.cppreference.com/w/cpp/ranges/slide_view). There's also [`std::ranges::views::adjacent`](https://en.cppreference.com/w/cpp/ranges/adjacent_view) which is a version of `slide` which takes the size as a compile-time rather than runtime parameter (and therefore can produce windows whose size is known at compile time).

Also [`chunk_by`](https://en.cppreference.com/w/cpp/ranges/chunk_by_view) as in https://github.com/michaelficarra/proposal-iterator-chunking/issues/1.